### PR TITLE
Fixed support of a template time type

### DIFF
--- a/examples/bank_renege.cpp
+++ b/examples/bank_renege.cpp
@@ -7,7 +7,7 @@
 
 struct config {
   int n_customers;
-  simcpp20::resource counters;
+  simcpp20::resource<> counters;
   std::uniform_real_distribution<> max_wait_time_dist;
   std::exponential_distribution<> arrival_interval_dist;
   std::exponential_distribution<> service_time_dist;

--- a/examples/carwash.cpp
+++ b/examples/carwash.cpp
@@ -8,7 +8,7 @@
 struct config {
   int initial_cars;
   double wash_time;
-  simcpp20::resource machines;
+  simcpp20::resource<> machines;
   std::uniform_int_distribution<> arrival_time_dist;
   std::default_random_engine gen;
 };

--- a/examples/machine_shop.cpp
+++ b/examples/machine_shop.cpp
@@ -7,7 +7,7 @@
 
 struct config {
   double repair_time;
-  simcpp20::resource repair_man;
+  simcpp20::resource<> repair_man;
   std::normal_distribution<> time_for_part_dist;
   std::exponential_distribution<> time_to_failure_dist;
   std::default_random_engine gen;

--- a/include/fschuetz04/simcpp20/resource.hpp
+++ b/include/fschuetz04/simcpp20/resource.hpp
@@ -8,8 +8,12 @@
 
 namespace simcpp20 {
 
-/// A shared resource holding a number of instances.
-class resource {
+/**
+ * A shared resource holding a number of instances.
+ *
+ * @tparam Time Type used for simulation time.
+ */
+template <typename Time = double> class resource {
 public:
   /**
    * Constructor.
@@ -17,7 +21,7 @@ public:
    * @param sim Reference to the simulation.
    * @param available Number of available instances. Defaults to 0.
    */
-  explicit resource(simulation<> &sim, uint64_t available = 0)
+  explicit resource(simulation<Time> &sim, uint64_t available = 0)
       : sim_{sim}, available_{available} {}
 
   /**
@@ -26,7 +30,7 @@ public:
    * @return An event that will be triggered once an instance is available,
    * which may be immediately.
    */
-  event<> request() {
+  event<Time> request() {
     auto ev = sim_.event();
     requests_.push(ev);
     trigger_requests();
@@ -44,10 +48,10 @@ public:
 
 private:
   /// Pending request events.
-  std::queue<event<>> requests_ = {};
+  std::queue<event<Time>> requests_ = {};
 
   /// Reference to the simulation.
-  simulation<> &sim_;
+  simulation<Time> &sim_;
 
   /// Number of available instances.
   uint64_t available_;

--- a/include/fschuetz04/simcpp20/store.hpp
+++ b/include/fschuetz04/simcpp20/store.hpp
@@ -14,8 +14,9 @@ namespace simcpp20 {
  * A shared store holding objects.
  *
  * @tparam T Type of objects to store.
+ * @tparam Time Type used for simulation time.
  */
-template <typename T> class store {
+template <typename T, typename Time = double> class store {
 public:
   /**
    * Constructor.
@@ -24,7 +25,7 @@ public:
    * @param capacity Maximum number of items the store can hold. Defaults to
    * unlimited.
    */
-  explicit store(simulation<> &sim,
+  explicit store(simulation<Time> &sim,
                  size_t capacity = std::numeric_limits<size_t>::max())
       : sim_{sim}, capacity_{capacity} {}
 
@@ -34,8 +35,8 @@ public:
    * @return An event that will be triggered with the next value
    * from the store once it is available, which may be immediately.
    */
-  value_event<T> get() {
-    auto ev = sim_.event<T>();
+  value_event<T, Time> get() {
+    auto ev = sim_.template event<T>();
 
     // add callback to trigger puts when this get is processed
     ev.add_callback([this]() { trigger_puts(); });
@@ -56,7 +57,7 @@ public:
    * @return An event that will be triggered when the store has capacity and the
    * value is added to the store, which may be immediately.
    */
-  event<> put(const T &value) {
+  event<Time> put(const T &value) {
     T copy = value;
     return put(std::move(copy));
   }
@@ -68,7 +69,7 @@ public:
    * @return An event that will be triggered when the store has capacity and the
    * value is added to the store, which may be immediately.
    */
-  event<> put(T &&value) {
+  event<Time> put(T &&value) {
     auto ev = sim_.event();
 
     // add callback to trigger gets when this put is processed
@@ -85,7 +86,7 @@ public:
 
 private:
   /// Reference to the simulation.
-  simulation<> &sim_;
+  simulation<Time> &sim_;
 
   /// Values currently in the store.
   std::queue<T> values_;
@@ -94,10 +95,10 @@ private:
   size_t capacity_;
 
   /// Pending get events.
-  std::queue<value_event<T>> gets_;
+  std::queue<value_event<T, Time>> gets_;
 
   /// Pairs of pending put events and the values to be put into the store.
-  std::queue<std::pair<event<>, T>> puts_;
+  std::queue<std::pair<event<Time>, T>> puts_;
 
   /// Trigger pending get events until the store is empty.
   void trigger_gets() {

--- a/tests/resource_tests.cpp
+++ b/tests/resource_tests.cpp
@@ -33,7 +33,7 @@ TEST_CASE("resource basics") {
 }
 
 simcpp20::process<> resource_user(simcpp20::simulation<> &sim,
-                                  simcpp20::resource &res, double use_time,
+                                  simcpp20::resource<> &res, double use_time,
                                   std::vector<double> &usage_times) {
   // request the resource
   co_await res.request();


### PR DESCRIPTION
There is no support of a template time type in the `store` and `resource` classes. We propose some changes that bring the template time type support into these classes.