### PR TITLE
Return number of events processed when run

### DIFF
--- a/include/fschuetz04/simcpp20/simulation.hpp
+++ b/include/fschuetz04/simcpp20/simulation.hpp
@@ -127,11 +127,19 @@ public:
     sev.ev_.process();
   }
 
-  /// Run the simulation until no more events are scheduled.
-  void run() {
-    while (!empty()) {
+  /**
+   * Run the simulation until no more events are scheduled.
+   * 
+   * @return Number of events processed.
+   */
+  std::size_t run() {
+    std::size_t count = 0;
+
+    for (; !empty(); count++) {
       step();
     }
+
+    return count;
   }
 
   /**

--- a/include/fschuetz04/simcpp20/simulation.hpp
+++ b/include/fschuetz04/simcpp20/simulation.hpp
@@ -148,15 +148,18 @@ public:
    * scheduled at or after the target time.
    *
    * @param target Target time.
+   * @return Number of events processed.
    */
-  void run_until(Time target) {
+  std::size_t run_until(Time target) {
     assert(target >= now());
+    std::size_t count = 0;
 
-    while (!empty() && scheduled_evs_.top().time_ < target) {
+    for (; !empty() && scheduled_evs_.top().time_ < target; count++) {
       step();
     }
 
     now_ = target;
+    return count;
   }
 
   /// @return Whether no events are scheduled.

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -194,5 +194,4 @@ TEST_CASE("run_until returns number of events processed") {
 
   auto count = sim.run_until(2.5);
   REQUIRE(count == 4);
-  REQUIRE(count == 4);
 }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -167,3 +167,17 @@ TEST_CASE("all_of") {
     REQUIRE(finished);
   }
 }
+
+TEST_CASE("run returns number of events processed") {
+  simcpp20::simulation<> sim;
+
+  auto ev1 = sim.timeout(1);
+  auto ev2 = sim.timeout(2);
+  auto ev3 = sim.timeout(3);
+  auto ev4 = sim.timeout(3);
+  auto ev5 = sim.timeout(2);
+  auto ev6 = sim.timeout(1);
+
+  auto count = sim.run();
+  REQUIRE(count == 6);
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -181,3 +181,18 @@ TEST_CASE("run returns number of events processed") {
   auto count = sim.run();
   REQUIRE(count == 6);
 }
+
+TEST_CASE("run_until returns number of events processed") {
+  simcpp20::simulation<> sim;
+
+  auto ev1 = sim.timeout(1); // Should be run
+  auto ev2 = sim.timeout(2); // Should be run
+  auto ev3 = sim.timeout(3); // Should not be run
+  auto ev4 = sim.timeout(3); // Should not be run
+  auto ev5 = sim.timeout(2); // Should be run
+  auto ev6 = sim.timeout(1); // Should be run
+
+  auto count = sim.run_until(2.5);
+  REQUIRE(count == 4);
+  REQUIRE(count == 4);
+}


### PR DESCRIPTION
This PR changes `simulation<>::run()` and `simulation<>::run_until()` so that they return a `std::size_t` with the number of events processed.

Tests included and passing.